### PR TITLE
refactor: convert api files to es module

### DIFF
--- a/api/download.js
+++ b/api/download.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+import axios from 'axios';
 
 const isFriendEnabled = true;
 
@@ -29,7 +29,7 @@ function extractDetailPathFromHtml(html, subjectId, movieTitle) {
   return lastMatch;
 }
 
-module.exports = async (req, res) => {
+export default async (req, res) => {
   const { tmdbId, header } = req.query;
   const TMDB_API_KEY = process.env.TMDB_API_KEY || '1e2d76e7c45818ed61645cb647981e5c';
 

--- a/api/tv.js
+++ b/api/tv.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+import axios from 'axios';
 
 const isFriendEnabled = true; // Toggle this to enable/disable 02movie requests
 
@@ -29,7 +29,7 @@ function extractDetailPathFromHtml(html, subjectId, movieTitle) {
   return lastMatch;
 }
 
-module.exports = async (req, res) => {
+export default async (req, res) => {
   const { tmdbId, season, episode, header } = req.query;
   const TMDB_API_KEY = process.env.TMDB_API_KEY || '1e2d76e7c45818ed61645cb647981e5c';
   const heading = header === '02movie' ? '02MOVIE' : 'SONiX MOVIES LTD';


### PR DESCRIPTION
Converted 'api/download.js' and 'api/tv.js' to use ES module syntax (import/export) to resolve 'require is not defined' error.